### PR TITLE
initial partial object caching framework

### DIFF
--- a/ci/new_tsqa/files/partial_object_caching_origin.json
+++ b/ci/new_tsqa/files/partial_object_caching_origin.json
@@ -1,0 +1,44 @@
+{
+    "processes": {
+        "origin1": {
+            "type": "origin",
+            "interfaces": {
+                "http": {
+                    "type": "http",
+                    "hostname": "127.0.0.1",
+                    "port": 8082
+                }
+            },
+            "actions": {
+                "GET": {
+                    "/chunked/down": {
+                        "type": "chunkedresponse",
+                        "status_code": 200,
+                        "headers": {
+                            "content-type": "text/plain"
+                        },
+                        "delay_first_chunk_sec": 1,
+                        "chunk_size_bytes": 1024,
+                        "num_chunks": 10,
+                        "delay_between_chunk_sec": 0,
+                        "chunk_byte_value": 99
+                    }
+                },
+                "POST": {
+                    "/nonchunked/up": {
+                        "type": "chunkedresponse",
+                        "status_code": 200,
+                        "headers": {
+                            "content-type": "text/plain"
+                        },
+                        "delay_first_chunk_sec": 0,
+                        "chunk_size_bytes": 1024,
+                        "num_chunks": 1,
+                        "delay_between_chunk_sec": 0,
+                        "chunk_byte_value": 99
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ci/new_tsqa/requirements.txt
+++ b/ci/new_tsqa/requirements.txt
@@ -4,3 +4,4 @@
 https://github.com/apache/trafficserver-qa/archive/master.zip
 pyyaml
 pyOpenSSL
+twisted

--- a/ci/new_tsqa/tests/canned_twisted_origin.py
+++ b/ci/new_tsqa/tests/canned_twisted_origin.py
@@ -1,0 +1,184 @@
+#!/bin/env python
+ 
+from twisted.web.resource import Resource, NoResource, UnsupportedMethod
+from twisted.web.server import Site
+from twisted.internet import reactor
+from twisted.python import log
+from twisted.web import server
+ 
+import sys
+import os
+import json
+ 
+# See http://twistedmatrix.com/documents/current/web/howto/web-in-60/index.html
+port = 80
+ 
+class ChunkedResponseResource(Resource):
+    def __init__(self, conf, method):
+        self.__conf = conf
+        self.__method = method
+        self.isLeaf = 1
+ 
+        if conf.has_key('status_code'):
+            self.__status_code = conf['status_code']
+        else:
+            self.__status_code = 200
+ 
+        if conf.has_key('headers'):
+            self.__headers = conf['headers']
+        else:
+            self.__headers = {}
+ 
+        if conf.has_key('num_chunks'):
+            self.__chunks_to_send = conf['num_chunks']
+        else:
+            self.__chunks_to_send = 0
+ 
+        if conf.has_key('delay_first_chunk_sec'):
+            self.__delay_first_chunk_sec = conf['delay_first_chunk_sec']
+        else:
+            self.__delay_first_chunk_sec = 0
+ 
+        if conf.has_key('delay_between_chunk_sec'):
+            self.__delay_between_chunk_sec = conf['delay_between_chunk_sec']
+        else:
+            self.__delay_between_chunk_sec = 0
+ 
+        if conf.has_key('chunk_byte_value'):
+            chunk_byte_value = conf['chunk_byte_value']
+        else:
+            chunk_byte_value = 42
+ 
+        if conf.has_key('chunk_size_bytes'):
+            chunk_size_bytes = conf['chunk_size_bytes']
+        else:
+            chunk_size_bytes = 1024
+ 
+        self.__chunk = chr(chunk_byte_value) * chunk_size_bytes
+ 
+    def __send_chunk(self, request, chunks_left):
+        request.write(self.__chunk)
+ 
+        if 1 == chunks_left:
+            request.finish()
+            return
+ 
+        reactor.callLater(self.__delay_between_chunk_sec, self.__send_chunk, request, chunks_left - 1)
+        return server.NOT_DONE_YET
+ 
+ 
+    def render(self, request):
+        """if self.__method != request.method:
+            request.setResponseCode(405)
+            return "" """
+ 
+        chunks_left = self.__chunks_to_send
+ 
+        for field_name, field_value in self.__headers.iteritems():
+            request.setHeader(bytes(field_name), bytes(field_value))
+ 
+        request.setResponseCode(self.__status_code)
+ 
+        if 0 == chunks_left:
+            return ""
+ 
+        reactor.callLater(self.__delay_first_chunk_sec, self.__send_chunk, request, chunks_left)
+        return server.NOT_DONE_YET
+
+class CannedTwistedOrigin:
+    def __init__(self, pname, cpath):
+        self.process_name = pname
+        self.config_path = cpath
+     
+        self.config = self.parse_config(self.config_path, self.process_name)
+        conf = self.config
+     
+        if not conf.has_key('interfaces') or not conf['interfaces'].has_key('http') or \
+            not conf['interfaces']['http'].has_key('port'):
+            raise Exception("'interfaces:http:port' does not exist for process '%s'" % self.process_name)
+     
+        if not conf.has_key('actions'):
+            raise Exception("'actions' does not exist for process '%s" % self.process_name)
+     
+        global port
+        port = conf['interfaces']['http']['port']
+    
+    def run(self):
+        log.startLogging(sys.stdout)
+     
+        reactor.listenTCP(port, Site(self.build_resource_tree(self.config['actions'])))
+        try:
+          reactor.run()
+        except:
+          reactor.stop()
+
+    def __del__(self):
+        reactor.stop()
+     
+    def build_resource_tree(self, actions):
+        """ build a static resource map that corresponds to the test case's config.json.  Limitation:  currently
+        only one abs_path per method can be supported due to blattj's limited understanding of the twisted api.
+     
+        :param actions: The origin process's 'actions' section from the test case's config.json
+        :return: a root resource with all sub-resources described in the config.json registered.
+        """
+        root = Resource()
+     
+        for method, paths in actions.iteritems():
+            for abs_path, conf in paths.iteritems():
+                if not conf.has_key('type'):
+                    raise Exception("conf for '%s:%s' is missing type" % (method, abs_path))
+     
+                # Add interior resources
+     
+                parent = root
+                abs_path = abs_path.split('/')
+                length = len(abs_path)
+     
+                for i in range(1, length - 1):
+                    child = parent.getStaticEntity(abs_path[i])
+     
+                    if not child or isinstance(child, NoResource):
+                        child = Resource()
+                        parent.putChild(abs_path[i], child)
+                    elif child.isLeaf:
+                        raise Exception("Leaf resource cannot contain other resources")
+     
+                    parent = child
+     
+                # Add leaf resource.   In the future other leaf resources can be added here
+     
+                type = conf['type']
+     
+                if type == 'chunkedresponse':
+                    child = ChunkedResponseResource(conf, method)
+                else:
+                    raise Exception("conf for %s:%s has unknown type '%s'" % (method, abs_path, type))
+     
+                parent.putChild(abs_path[length - 1], child)
+     
+        return root
+
+    def get_port(self):
+        return port
+     
+    def parse_config(self, config_path='config.json', process_name=None):
+        """ Get the test manager's parsed configuration file
+        :param process_name: Optional: if supplied return only subdoc for the process.  Else return the entire config
+        """
+     
+        if not os.path.isfile(config_path):
+            raise Exception("Config file '%s' does not exist" % config_path)
+     
+        conf = json.load(open(config_path, 'r'), encoding='utf-8')
+     
+        if not process_name:
+            return conf
+     
+        if not conf.has_key('processes'):
+            raise Exception("Configuration has no 'processes' section")
+     
+        if not conf['processes'].has_key(process_name):
+            raise Exception("Configuration has no '%s' process" % process_name)
+     
+        return conf['processes'][process_name]

--- a/ci/new_tsqa/tests/test_partial_object_caching.py
+++ b/ci/new_tsqa/tests/test_partial_object_caching.py
@@ -1,0 +1,91 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+import sys
+import requests
+import time
+import logging
+#import subprocess
+import threading
+
+import helpers
+import canned_twisted_origin
+
+import tsqa.test_cases
+import tsqa.utils
+import tsqa.endpoint
+
+log = logging.getLogger(__name__)
+
+#TODO
+#rewrite origin as class again.
+#separate init from run
+#run in background thread
+
+class TestPartialObjectCachingHTTP(helpers.EnvironmentCase):
+    @classmethod
+    def setUpEnv(cls, env):
+        '''
+        This function is responsible for setting up the environment for this fixture
+        This includes everything pre-daemon start
+        '''
+        # remap to canned origin host
+        cls.origin_process = canned_twisted_origin.CannedTwistedOrigin('origin1',
+          helpers.tests_file_path('partial_object_caching_origin.json'))
+        cls.__background_thread = threading.Thread(target=cls.origin_process.run)
+        cls.__background_thread.setDaemon(True)
+        cls.__background_thread.start()
+        
+        #cls.origin_process.run() #run this in new thread
+        #cls.origin_process = subprocess.Popen([sys.executable, 'tests/canned_twisted_origin.py', 'origin1',
+        #  helpers.tests_file_path('partial_object_caching_origin.json')], shell=False, env=os.environ.copy(), bufsize=0,
+        #  stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        cls.origin_port = cls.origin_process.get_port()
+        cls.configs['remap.config'].add_line('map / http://127.0.0.1:{0}/\n'.format(cls.origin_port))
+
+        # only add server headers when there weren't any
+        cls.configs['records.config']['CONFIG']['proxy.config.http.response_server_enabled'] = 2
+        cls.configs['records.config']['CONFIG']['proxy.config.http.keep_alive_enabled_out'] = 1
+        cls.configs['records.config']['CONFIG']['share_server_session'] = 2
+
+        # set only one ET_NET thread (so we don't have to worry about the per-thread pools causing issues)
+        cls.configs['records.config']['CONFIG']['proxy.config.exec_thread.limit'] = 1
+        cls.configs['records.config']['CONFIG']['proxy.config.exec_thread.autoconfig'] = 0
+
+    #def tearDown(cls):
+    #    cls.__background_thread.join()
+    
+    def test_POC_1(self):
+        '''
+        Test 1 that the origin does in fact support partial object caching
+        '''
+        #log.info(self.origin_process.poll())
+        with requests.Session() as s:
+            url = 'http://127.0.0.1:{0}/chunked/down/'.format(self.origin_port)
+            ret = s.get(url)
+            self.assertEqual(ret.status_code, 200)
+            #self.assertEqual(len(ret.text), int(ret.headers['content-length'])) TODO add support to origin for content
+            #length header
+    
+    def test_POC_1_proxy(self):
+        '''
+        Test 1 that partial object caching works through ATS to that origin
+        '''
+        url = 'http://127.0.0.1:{0}/chunked/down/'.format(self.origin_port)
+        ret = requests.get(url, proxies=self.proxies)
+        self.assertEqual(ret.status_code, 200)
+        #self.assertEqual(len(ret.text), int(ret.headers['content-length']))

--- a/ci/new_tsqa/tests/test_partial_object_caching_ATLAS.py
+++ b/ci/new_tsqa/tests/test_partial_object_caching_ATLAS.py
@@ -1,0 +1,210 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+import requests
+import time
+import logging
+
+import helpers
+
+import tsqa.test_cases
+import tsqa.utils
+import tsqa.endpoint
+
+log = logging.getLogger(__name__)
+
+class TestPartialObjectCachingHTTP(helpers.EnvironmentCase):
+    @classmethod
+    def setUpEnv(cls, env):
+        '''
+        This function is responsible for setting up the environment for this fixture
+        This includes everything pre-daemon start
+        '''
+        # remap to ATLAS host
+        cls.atlas_host = 'qa01atlasdlv01.vpg.gq1.yahoo.com'
+        cls.configs['remap.config'].add_line('map / http://{0}/\n'.format(cls.atlas_host))
+
+        # only add server headers when there weren't any
+        cls.configs['records.config']['CONFIG']['proxy.config.http.response_server_enabled'] = 2
+        cls.configs['records.config']['CONFIG']['proxy.config.http.keep_alive_enabled_out'] = 1
+        cls.configs['records.config']['CONFIG']['share_server_session'] = 2
+
+        # set only one ET_NET thread (so we don't have to worry about the per-thread pools causing issues)
+        cls.configs['records.config']['CONFIG']['proxy.config.exec_thread.limit'] = 1
+        cls.configs['records.config']['CONFIG']['proxy.config.exec_thread.autoconfig'] = 0
+    
+    def test_POC_1(self):
+        '''
+        Test 1 that the origin does in fact support partial object caching
+        '''
+        with requests.Session() as s:
+            url = 'http://{0}/qa/large'.format(self.atlas_host)
+            queries = {'a': 'qa1', 's': '67c65b02bc8c7f7a95d9d7ba24aceebe'}
+            ret = s.get(url, params=queries)
+            log.info('content-length: {0}'.format(ret.headers['content-length']))
+            self.assertEqual(ret.status_code, 200)
+            self.assertEqual(len(ret.text), int(ret.headers['content-length']))
+    
+    def test_POC_1_proxy(self):
+        '''
+        Test 1 that partial object caching works through ATS to that origin
+        '''
+        url = 'http://{0}/qa/large'.format(self.atlas_host)
+        queries = {'a': 'qa1', 's': '67c65b02bc8c7f7a95d9d7ba24aceebe'}
+        ret = requests.get(url, params=queries, proxies=self.proxies)
+        log.info('content-length: {0}'.format(ret.headers['content-length']))
+        self.assertEqual(ret.status_code, 200)
+        self.assertEqual(len(ret.text), int(ret.headers['content-length']))
+     
+    def test_POC_2(self):
+        '''
+        Test 2 that the origin does in fact support partial object caching
+        '''
+        with requests.Session() as s:
+            url = 'http://{0}/qa/big_buck_bunny.mp4'.format(self.atlas_host)
+            queries = {'a': 'qa1', 's': '0d89160ab9e8c602c3772af8a152e03e'}
+            ret = s.get(url, params=queries)
+            log.info('content-length: {0}'.format(ret.headers['content-length']))
+            self.assertEqual(ret.status_code, 200)
+            self.assertEqual(len(ret.text), int(ret.headers['content-length']))
+    
+    def test_POC_2_proxy(self):
+        '''
+        Test 2 that partial object caching works through ATS to that origin
+        '''
+        url = 'http://{0}/qa/big_buck_bunny.mp4'.format(self.atlas_host)
+        queries = {'a': 'qa1', 's': '0d89160ab9e8c602c3772af8a152e03e'}
+        ret = requests.get(url, params=queries, proxies=self.proxies)
+        log.info('content-length: {0}'.format(ret.headers['content-length']))
+        self.assertEqual(ret.status_code, 200)
+        self.assertEqual(len(ret.text), int(ret.headers['content-length']))       
+
+    def test_POC_3(self):
+        '''
+        Test 3 that the origin does in fact support partial object caching
+        '''
+        with requests.Session() as s:
+            url = 'http://{0}/qa/big_buck_bunny.mp4'.format(self.atlas_host)
+            queries = {'a': 'qa1', 's': '0d89160ab9e8c602c3772af8a152e03e'}
+            headers = {'Range': 'bytes=0-20000'}
+            ret = s.get(url, params=queries, headers=headers)
+            log.info('content-length: {0}'.format(ret.headers['content-length']))
+            self.assertEqual(ret.status_code, 206)
+            self.assertEqual(len(ret.text), int(ret.headers['content-length']))
+    
+    def test_POC_3_proxy(self):
+        '''
+        Test 3 that partial object caching works through ATS to that origin
+        '''
+        url = 'http://{0}/qa/big_buck_bunny.mp4'.format(self.atlas_host)
+        queries = {'a': 'qa1', 's': '0d89160ab9e8c602c3772af8a152e03e'}
+        headers = {'Range': 'bytes=0-20000'}
+        ret = requests.get(url, params=queries, headers=headers, proxies=self.proxies)
+        log.info('content-length: {0}'.format(ret.headers['content-length']))
+        self.assertEqual(ret.status_code, 206)
+        self.assertEqual(len(ret.text), int(ret.headers['content-length']))
+
+class TestPartialObjectCachingHTTPS(helpers.EnvironmentCase):
+    @classmethod
+    def setUpEnv(cls, env):
+        '''
+        This function is responsible for setting up the environment for this fixture
+        This includes everything pre-daemon start
+        '''
+        # remap to ATLAS host
+        cls.atlas_host = 'qa01atlasdlv01.vpg.gq1.yahoo.com'
+        cls.configs['remap.config'].add_line('map / https://{0}/\n'.format(cls.atlas_host))
+
+        # only add server headers when there weren't any
+        cls.configs['records.config']['CONFIG']['proxy.config.http.response_server_enabled'] = 2
+        cls.configs['records.config']['CONFIG']['proxy.config.http.keep_alive_enabled_out'] = 1
+        cls.configs['records.config']['CONFIG']['share_server_session'] = 2
+
+        # set only one ET_NET thread (so we don't have to worry about the per-thread pools causing issues)
+        cls.configs['records.config']['CONFIG']['proxy.config.exec_thread.limit'] = 1
+        cls.configs['records.config']['CONFIG']['proxy.config.exec_thread.autoconfig'] = 0
+    
+    def test_POC_1(self):
+        '''
+        Test 1 that the origin does in fact support partial object caching
+        '''
+        with requests.Session() as s:
+            url = 'https://{0}/qa/large'.format(self.atlas_host)
+            queries = {'a': 'qa1', 's': '67c65b02bc8c7f7a95d9d7ba24aceebe'}
+            ret = s.get(url, params=queries, verify=False)
+            log.info('content-length: {0}'.format(ret.headers['content-length']))
+            self.assertEqual(ret.status_code, 200)
+            self.assertEqual(len(ret.text), int(ret.headers['content-length']))
+    
+    def test_POC_1_proxy(self):
+        '''
+        Test 1 that partial object caching works through ATS to that origin
+        '''
+        url = 'https://{0}/qa/large'.format(self.atlas_host)
+        queries = {'a': 'qa1', 's': '67c65b02bc8c7f7a95d9d7ba24aceebe'}
+        ret = requests.get(url, params=queries, proxies=self.proxies, verify=False)
+        log.info('content-length: {0}'.format(ret.headers['content-length']))
+        self.assertEqual(ret.status_code, 200)
+        self.assertEqual(len(ret.text), int(ret.headers['content-length']))
+     
+    def test_POC_2(self):
+        '''
+        Test 2 that the origin does in fact support partial object caching
+        '''
+        with requests.Session() as s:
+            url = 'https://{0}/qa/big_buck_bunny.mp4'.format(self.atlas_host)
+            queries = {'a': 'qa1', 's': '0d89160ab9e8c602c3772af8a152e03e'}
+            ret = s.get(url, params=queries, verify=False)
+            log.info('content-length: {0}'.format(ret.headers['content-length']))
+            self.assertEqual(ret.status_code, 200)
+            self.assertEqual(len(ret.text), int(ret.headers['content-length']))
+    
+    def test_POC_2_proxy(self):
+        '''
+        Test 2 that partial object caching works through ATS to that origin
+        '''
+        url = 'https://{0}/qa/big_buck_bunny.mp4'.format(self.atlas_host)
+        queries = {'a': 'qa1', 's': '0d89160ab9e8c602c3772af8a152e03e'}
+        ret = requests.get(url, params=queries, proxies=self.proxies, verify=False)
+        log.info('content-length: {0}'.format(ret.headers['content-length']))
+        self.assertEqual(ret.status_code, 200)
+        self.assertEqual(len(ret.text), int(ret.headers['content-length']))       
+
+    def test_POC_3(self):
+        '''
+        Test 3 that the origin does in fact support partial object caching
+        '''
+        with requests.Session() as s:
+            url = 'https://{0}/qa/big_buck_bunny.mp4'.format(self.atlas_host)
+            queries = {'a': 'qa1', 's': '0d89160ab9e8c602c3772af8a152e03e'}
+            headers = {'Range': 'bytes=0-20000'}
+            ret = s.get(url, params=queries, headers=headers, verify=False)
+            log.info('content-length: {0}'.format(ret.headers['content-length']))
+            self.assertEqual(ret.status_code, 206)
+            self.assertEqual(len(ret.text), int(ret.headers['content-length']))
+    
+    def test_POC_3_proxy(self):
+        '''
+        Test 3 that partial object caching works through ATS to that origin
+        '''
+        url = 'https://{0}/qa/big_buck_bunny.mp4'.format(self.atlas_host)
+        queries = {'a': 'qa1', 's': '0d89160ab9e8c602c3772af8a152e03e'}
+        headers = {'Range': 'bytes=0-20000'}
+        ret = requests.get(url, params=queries, headers=headers, proxies=self.proxies, verify=False)
+        log.info('content-length: {0}'.format(ret.headers['content-length']))
+        self.assertEqual(ret.status_code, 206)
+        self.assertEqual(len(ret.text), int(ret.headers['content-length']))


### PR DESCRIPTION
this is an initial partial object caching test set. 

TODO:

add origin support for byte range requests
add origin support for returning content length header
might be a thread issue. consult with @duderino 
